### PR TITLE
Fix widget test timing

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -21,7 +21,7 @@ void main() {
 
     // Tap the '+' icon and trigger a frame.
     await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     // Verify that our counter has incremented.
     expect(find.text('0'), findsNothing);


### PR DESCRIPTION
## Summary
- ensure widget test waits for animations by using `pumpAndSettle`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689589470f408329bd927472569feb72